### PR TITLE
BaSP-Hotfix: Close security window

### DIFF
--- a/src/controllers/super-admins.js
+++ b/src/controllers/super-admins.js
@@ -128,7 +128,10 @@ export const updateSuperAdmins = async (req, res) => {
 
 export const deletedSuperAdmins = async (req, res) => {
   try {
-    await firebase.auth().deleteUser(req.firebaseUid);
+    const { token } = req.headers;
+    const user = await firebase.auth().verifyIdToken(token);
+    const firebaseUid = user.uid;
+    await firebase.auth().deleteUser(firebaseUid);
 
     const { id } = req.params;
     if (!isValidObjectId(req.params.id)) {

--- a/src/routes/super-admins.js
+++ b/src/routes/super-admins.js
@@ -10,7 +10,7 @@ const router = express.Router();
 router
   .get('/', checkAuth(['super-admin']), getAllSuperAdmins)
   .get('/:id', checkAuth(['super-admin']), getSuperAdminsById)
-  .post('/', validateUser, createSuperAdmins)
+  .post('/', checkAuth(['super-admin']), validateUser, createSuperAdmins)
   .put('/:id', checkAuth(['super-admin']), validateUser, updateSuperAdmins)
   .delete('/:id', checkAuth(['super-admin']), deletedSuperAdmins);
 


### PR DESCRIPTION
To validate _**super-admins**_ creations we add a middleware validations to allow it functions just for other exist super-admins.


Now is not longer possible create new **_super-admins_** from **Postman**
![image](https://user-images.githubusercontent.com/96196361/205318614-d84f06e5-f124-4195-8098-0fa073614fd9.png)

POST method is now close to other "super-admins":
![image](https://user-images.githubusercontent.com/96196361/205318790-3b80b3ef-b730-42f5-adc6-5f457b89e8be.png)

